### PR TITLE
show updates for non-final packages 

### DIFF
--- a/src/z3c/checkversions/base.py
+++ b/src/z3c/checkversions/base.py
@@ -77,7 +77,7 @@ class Checker(object):
         By default, the highest version is found.
         """
         versions = self.get_versions()
-        
+
         for name, version in sorted(versions.items()):
             if self.incremental == 'stop':
                 # skip subsequent scans
@@ -119,7 +119,7 @@ class Checker(object):
                 if self.incremental == True:
                     self.incremental = 'stop'
                 if self.verbose:
-                    print("%s=%s # was: %s=%s" % (name, new_dist.version, name, version))
+                    print("%s=%s # was: %s" % (name, new_dist.version, version))
                 else:
                     print("%s=%s" % (name, new_dist.version))
             elif self.verbose:

--- a/src/z3c/checkversions/buildout.txt
+++ b/src/z3c/checkversions/buildout.txt
@@ -61,8 +61,8 @@ using grep (``bin/checkversions -v | grep was``)
 >>> checker = buildout.Checker(filename=buildout_path, verbose=True)
 >>> checker.check(level=2)
 # Checking buildout file ...
-zope.component=3.0.3 # was: zope.component=3.0.0
-zope.interface=3.4.1 # was: zope.interface=3.4.0
+zope.component=3.0.3 # was: 3.0.0
+zope.interface=3.4.1 # was: 3.4.0
 
 The old comments are removed:
 
@@ -80,8 +80,8 @@ The old comments are removed:
 >>> checker = buildout.Checker(filename=buildout_path, verbose=True)
 >>> checker.check()
 # Checking buildout file ...
-zope.component=3.9.4 # was: zope.component=3.0.3
-zope.interface=3.6.1 # was: zope.interface=3.4.1
+zope.component=3.9.4 # was: 3.0.3
+zope.interface=3.6.1 # was: 3.4.1
 
 We can provide a blacklist file, containing versions to not suggest.
 This file may come from a buildbot remembering failures.
@@ -95,8 +95,8 @@ This file may come from a buildbot remembering failures.
 ...                            blacklist=blacklist_path)
 >>> checker.check()
 # Checking buildout file ...
-zope.component=3.9.2 # was: zope.component=3.0.3
-zope.interface=3.6.1 # was: zope.interface=3.4.1
+zope.component=3.9.2 # was: 3.0.3
+zope.interface=3.6.1 # was: 3.4.1
 
 We can let the checker to suggest only one new package. This should be used to
 test a just single new package against a set of other packages.
@@ -107,7 +107,7 @@ test a just single new package against a set of other packages.
 ...                            blacklist=blacklist_path)
 >>> checker.check()
 # Checking buildout file ...
-zope.component=3.9.2 # was: zope.component=3.0.3
+zope.component=3.9.2 # was: 3.0.3
 zope.interface=3.4.1
 
 >>> os.remove(blacklist_path)
@@ -151,6 +151,6 @@ pinned.
 # Checking buildout file ...
 distribute=
 zc.buildout=...
-zope.component=3.9.4 # was: zope.component=3.0.0
+zope.component=3.9.4 # was: 3.0.0
 
 >>> os.remove(buildout_path)


### PR DESCRIPTION
could you please review the change, merge it and and do a new release on pypi?

w/o this change newer non-final releases for non-final package versions are not shown.

in addition i changed the output that the old version is in the same line so it's easy to grep for eggs that can be updated: `bin/checkversions -v versions.cfg | grep was`
