### PR TITLE
Improve documentation for buildout support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Changelog
 
 - Drop support for Python 3.4.
 
+- Improve error message in case zc.buildout is not installed.
+
+- Improve installation instruction.
+
 
 1.1 (2018-11-03)
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,11 @@ or in a buildout::
 Note that buildout support is optional and must be enabled with [buildout] so
 that zc.buildout is installed as well.
 
+If you need buildout support while installing this package via pip
+you have to install it like this:
+
+    pip install z3c.checkversions[buildout]
+
 Usage
 =====
 

--- a/src/z3c/checkversions/buildout.py
+++ b/src/z3c/checkversions/buildout.py
@@ -19,7 +19,12 @@ except ImportError:
         "zc.buildout is not installed! \n"
         "If you're in a buildout environment,\n"
         "enable the buildout extra requirement like this:\n"
-        "eggs = z3c.checkversions [buildout]")
+        "eggs = z3c.checkversions [buildout]\n"
+        "If you installed z3c.checkversions via pip,\n"
+        "please first uninstall this package,\n"
+        "and then re-install it like this:\n"
+        "pip install z3c.checkversions[buildout]\n"
+        "or install zc.buildout separately.")
 
 from z3c.checkversions import base
 

--- a/src/z3c/checkversions/buildout.py
+++ b/src/z3c/checkversions/buildout.py
@@ -21,10 +21,7 @@ except ImportError:
         "enable the buildout extra requirement like this:\n"
         "eggs = z3c.checkversions [buildout]\n"
         "If you installed z3c.checkversions via pip,\n"
-        "please first uninstall this package,\n"
-        "and then re-install it like this:\n"
-        "pip install z3c.checkversions[buildout]\n"
-        "or install zc.buildout separately.")
+        "please make sure to also install zc.buildout.")
 
 from z3c.checkversions import base
 


### PR DESCRIPTION
... both for the README and the exception message, which gets raised
when zc.buildout is not installed.

modified:   CHANGES.rst
modified:   README.rst
modified:   src/z3c/checkversions/buildout.py