### PR TITLE
Fix parsing of versions that are really requirements specifications

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix parsing of versions that are really requirements specifications.
+  (`#24 <https://github.com/zopefoundation/z3c.checkversions/issues/24>`_)
 
 
 2.0 (2023-02-14)

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'setuptools >= 8, < 66',
+        'setuptools >= 8',
     ],
     python_requires='>=3.7',
     extras_require={

--- a/src/z3c/checkversions/base.py
+++ b/src/z3c/checkversions/base.py
@@ -86,7 +86,17 @@ class Checker:
                 # skip subsequent scans
                 print("{}={}".format(name, version))
                 continue
-            parsed_version = parse_version(version)
+
+            try:
+                parsed_version = parse_version(version)
+            except ValueError:
+                # This could be a requirements specification instead
+                # of a straight version number
+                req = Requirement(f'{name}{version}')
+                for spec in req.specifier:
+                    parsed_version = parse_version(spec.version)
+                    break  # Just use the first one
+
             req = Requirement.parse(name)
             self.pi.find_packages(req)
             new_dist = None


### PR DESCRIPTION
Fixes #24 

I didn't check but it appears setuptools <66 did not complain when a version specifier was actually a requirements specifier. This PR explicitly checks for such cases and attempts to convert requirements specifiers to versions.

With this change running `bin/checkversions` against the Zope versions files works again.