### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 3.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 2.2 (2025-04-09)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2.3 (unreleased)
+3.0 (unreleased)
 ----------------
 
 - Nothing changed yet.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 
 setup(
     name='z3c.checkversions',
-    version='2.3.dev0',
+    version='3.0.dev0',
     description="Find newer package versions on PyPI",
     long_description=(open("README.rst").read() + "\n" +
                       open("CHANGES.rst").read()),

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@
 #
 ##############################################################################
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -48,9 +47,6 @@ setup(
     author_email='zope-dev@zope.dev',
     url='https://github.com/zopefoundation/z3c.checkversions',
     license='ZPL-2.1',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['z3c'],
     include_package_data=True,
     zip_safe=False,
     install_requires=[

--- a/src/z3c/__init__.py
+++ b/src/z3c/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: nocover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
